### PR TITLE
Moves quickstart screenshot to the QuickStart Demo section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,6 @@ extension ViewController: TriggerDelegate {
 
 ## Quick Start - Objective-C Core SDK
 
-![quickstart](images/cs710s-ios.png)
-
 ### 1. Initialize
 
 ```objective-c
@@ -387,6 +385,8 @@ Automatic frequency configuration for:
 - And more...
 
 ## QuickStart Demo
+
+![quickstart](images/cs710s-ios.png)
 
 The demo app demonstrates complete RFID workflows:
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the `README.md` file, moving the placement of the quickstart image to a more appropriate section for improved documentation clarity.

- Documentation update:
  * Moved the `quickstart` image (`images/cs710s-ios.png`) from the Objective-C Core SDK section to the QuickStart Demo section in `README.md` for better contextual relevance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L262-L263) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R389-R390)Relocates the visual aid from the Objective-C Core SDK initialization section to the QuickStart Demo section to better align with the demo application documentation.